### PR TITLE
Fix docs for misspelt env var X_VCPKG_NUGET_ID_PREFIX

### DIFF
--- a/vcpkg/users/config-environment.md
+++ b/vcpkg/users/config-environment.md
@@ -1,7 +1,7 @@
 ---
 title: Environment variables
 description: Use environment variables to control how vcpkg works and where it looks for files.
-ms.date: 01/10/2024
+ms.date: 05/27/2024
 ms.topic: reference
 ---
 # Environment variables
@@ -96,15 +96,15 @@ This environment variable changes the metadata of produced NuGet packages. See [
 
 This environment variable allows using NuGet's cache for every nuget-based binary source. See [Binary Caching](../reference/binarycaching.md#nuget) for more details.
 
-## X_VCPKG_NUGET_PREFIX
+## X_VCPKG_NUGET_ID_PREFIX
 
 Adds a prefix to the name of all the binary packages pushed or restored from
 [NuGet binary caches](../reference/binarycaching.md#nuget).
 
-For example, when `X_VCPKG_NUGET_PREFIX` is set to `vcpkg_demo-` the
+For example, when `X_VCPKG_NUGET_ID_PREFIX` is set to `vcpkg_demo` the
 `zlib_x64-windows.1.2.13-vcpkg8918746ce8b60474e5ebe68e53355fa70eb05119be913a1d1dc0b930b3b7b6e8.nupkg`
 binary package becomes
-`vcpkg_demo-zlib_x64-windows.1.2.13-vcpkg8918746ce8b60474e5ebe68e53355fa70eb05119be913a1d1dc0b930b3b7b6e8.nupkg`.
+`vcpkg_demo_zlib_x64-windows.1.2.13-vcpkg8918746ce8b60474e5ebe68e53355fa70eb05119be913a1d1dc0b930b3b7b6e8.nupkg`.
 
 ## X_VCPKG_ASSET_SOURCES
 


### PR DESCRIPTION
https://github.com/microsoft/vcpkg-tool/blob/76f1e5d58602ff1feb0a0942f8fb2bfc78ac4b44/include/vcpkg/base/contractual-constants.h#L496

Also, the tool will automatically insert `_` as separator between prefix and env var: https://github.com/microsoft/vcpkg-tool/blob/76f1e5d58602ff1feb0a0942f8fb2bfc78ac4b44/src/vcpkg/binarycaching.cpp#L1881